### PR TITLE
feat: 增加开房间 DEMO（桌游/组队类游戏）

### DIFF
--- a/GameFrameX.Apps/Game/DiceBattle/Component/DiceBattleGameComponent.cs
+++ b/GameFrameX.Apps/Game/DiceBattle/Component/DiceBattleGameComponent.cs
@@ -1,0 +1,37 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+using GameFrameX.Apps.Game.DiceBattle.Entity;
+
+namespace GameFrameX.Apps.Game.DiceBattle.Component;
+
+[ComponentType(GlobalConst.ActorTypeServer)]
+public sealed class DiceBattleGameComponent : StateComponent<DiceBattleGameListState>
+{
+}

--- a/GameFrameX.Apps/Game/DiceBattle/Entity/DiceBattleGameListState.cs
+++ b/GameFrameX.Apps/Game/DiceBattle/Entity/DiceBattleGameListState.cs
@@ -1,0 +1,66 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+namespace GameFrameX.Apps.Game.DiceBattle.Entity;
+
+public sealed class DiceBattleGameListState : CacheState
+{
+    /// <summary>
+    /// Key: 房间ID，Value: 掷骰子比大小玩法数据。
+    /// </summary>
+    public Dictionary<long, DiceBattleGameState> Games { get; set; } = new Dictionary<long, DiceBattleGameState>();
+}
+
+public sealed class DiceBattleGameState
+{
+    /// <summary>
+    /// 房间ID。
+    /// </summary>
+    public long RoomId { get; set; }
+
+    /// <summary>
+    /// 当前局数。
+    /// </summary>
+    public int Round { get; set; } = 1;
+
+    /// <summary>
+    /// 玩家掷骰记录。Key: 玩家ID, Value: 骰子点数(1-6)。
+    /// </summary>
+    public Dictionary<long, int> DiceMap { get; set; } = new Dictionary<long, int>();
+
+    /// <summary>
+    /// 胜利玩家ID列表。点数最大者获胜，并列时全部记录；未结算前为空。
+    /// </summary>
+    public List<long> WinnerRoleIds { get; set; } = new List<long>();
+
+    /// <summary>
+    /// 最大骰子点数。未结算前为0。
+    /// </summary>
+    public int MaxDiceValue { get; set; }
+}

--- a/GameFrameX.Hotfix/Logic/Game/DiceBattle/DiceBattleGameComponentAgent.cs
+++ b/GameFrameX.Hotfix/Logic/Game/DiceBattle/DiceBattleGameComponentAgent.cs
@@ -1,0 +1,276 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+using GameFrameX.Apps.Common.Session;
+using GameFrameX.Apps.Game.DiceBattle.Component;
+using GameFrameX.Apps.Game.DiceBattle.Entity;
+using GameFrameX.Hotfix.Logic.Game.Room;
+
+namespace GameFrameX.Hotfix.Logic.Game.DiceBattle;
+
+public class DiceBattleGameComponentAgent : StateComponentAgent<DiceBattleGameComponent, DiceBattleGameListState>
+{
+    /// <summary>
+    /// 骰子点数上界（Next 上界 exclusive），点数范围为 1-6。
+    /// </summary>
+    private const int DiceUpperBound = 7;
+
+    /// <summary>
+    /// 骰子点数下界（Next 下界 inclusive）。
+    /// </summary>
+    private const int DiceLowerBound = 1;
+
+    public async Task OnReqGameInfoAsync(ReqDiceBattleGameInfo request, RespDiceBattleGameInfo response)
+    {
+        var roomAgent = await ActorManager.GetComponentAgent<RoomComponentAgent>();
+        var room = await roomAgent.GetRoom(request.RoomId);
+        if (!CheckRoom(room, response))
+        {
+            return;
+        }
+
+        var game = GetOrCreateGame(room.RoomId, room.Round);
+        response.GameInfo = ToMessage(game, room.PlayerIds, CanRevealDice(room.Status));
+    }
+
+    public async Task OnRollDiceAsync(long roleId, ReqRollDiceBattle request, RespRollDiceBattle response)
+    {
+        if (!CheckRoleId(roleId, response))
+        {
+            return;
+        }
+
+        var roomAgent = await ActorManager.GetComponentAgent<RoomComponentAgent>();
+        var room = await roomAgent.GetRoom(request.RoomId);
+        if (!CheckRoom(room, response))
+        {
+            return;
+        }
+
+        if (room.Status != RoomStatus.Playing || !room.PlayerIds.Contains(roleId))
+        {
+            response.ErrorCode = (int)OperationStatusCode.Forbidden;
+            response.GameInfo = BuildGameInfo(room, false);
+            return;
+        }
+
+        var game = GetOrCreateGame(room.RoomId, room.Round);
+        if (game.DiceMap.ContainsKey(roleId))
+        {
+            response.ErrorCode = (int)OperationStatusCode.HasExist;
+            response.GameInfo = ToMessage(game, room.PlayerIds, false);
+            return;
+        }
+
+        // 服务器端生成骰子点数，玩家无法篡改。
+        game.DiceMap[roleId] = RandomHelper.Next(DiceLowerBound, DiceUpperBound);
+        var revealDice = false;
+        if (game.DiceMap.Count == room.PlayerIds.Count)
+        {
+            await roomAgent.EnterSettling(room.RoomId);
+            CalculateWinners(room.PlayerIds, game);
+            await OwnerComponent.WriteStateAsync();
+            await roomAgent.MarkSettled(room.RoomId);
+            revealDice = true;
+        }
+        else
+        {
+            await OwnerComponent.WriteStateAsync();
+        }
+
+        response.GameInfo = ToMessage(game, room.PlayerIds, revealDice);
+        await NotifyGameChangedAsync(room.PlayerIds, response.GameInfo);
+    }
+
+    public async Task OnRestartGameAsync(long roleId, ReqRestartDiceBattle request, RespRestartDiceBattle response)
+    {
+        if (!CheckRoleId(roleId, response))
+        {
+            return;
+        }
+
+        var roomAgent = await ActorManager.GetComponentAgent<RoomComponentAgent>();
+        var room = await roomAgent.GetRoom(request.RoomId);
+        if (!CheckRoom(room, response))
+        {
+            return;
+        }
+
+        if (room.OwnerRoleId != roleId || room.Status != RoomStatus.Settled)
+        {
+            response.ErrorCode = (int)OperationStatusCode.Forbidden;
+            response.GameInfo = BuildGameInfo(room, CanRevealDice(room.Status));
+            return;
+        }
+
+        var roomInfo = await roomAgent.RestartRoomGame(room.RoomId);
+        if (roomInfo == null || roomInfo.Status != RoomStatus.Playing)
+        {
+            response.ErrorCode = (int)OperationStatusCode.Unprocessable;
+            response.GameInfo = BuildGameInfo(room, CanRevealDice(room.Status));
+            return;
+        }
+
+        var game = GetOrCreateGame(room.RoomId, room.Round);
+        game.DiceMap.Clear();
+        game.WinnerRoleIds.Clear();
+        game.MaxDiceValue = 0;
+        await OwnerComponent.WriteStateAsync();
+
+        response.GameInfo = ToMessage(game, room.PlayerIds, false);
+        await NotifyGameChangedAsync(room.PlayerIds, response.GameInfo);
+    }
+
+    private DiceBattleGameInfo BuildGameInfo(GameFrameX.Apps.Game.Room.Entity.RoomState room, bool revealDice)
+    {
+        var game = GetOrCreateGame(room.RoomId, room.Round);
+        return ToMessage(game, room.PlayerIds, revealDice);
+    }
+
+    private DiceBattleGameState GetOrCreateGame(long roomId, int round)
+    {
+        if (!State.Games.TryGetValue(roomId, out var game))
+        {
+            game = new DiceBattleGameState
+            {
+                RoomId = roomId,
+                Round = round,
+            };
+            State.Games[roomId] = game;
+        }
+
+        if (game.Round != round)
+        {
+            game.Round = round;
+            game.DiceMap.Clear();
+            game.WinnerRoleIds.Clear();
+            game.MaxDiceValue = 0;
+        }
+
+        return game;
+    }
+
+    private static bool CheckRoleId(long roleId, IResponseMessage response)
+    {
+        if (roleId > 0)
+        {
+            return true;
+        }
+
+        SetResponseErrorCode(response, (int)OperationStatusCode.Forbidden);
+        return false;
+    }
+
+    private static bool CheckRoom(GameFrameX.Apps.Game.Room.Entity.RoomState room, IResponseMessage response)
+    {
+        if (room == null)
+        {
+            SetResponseErrorCode(response, (int)OperationStatusCode.NotFound);
+            return false;
+        }
+
+        if (room.GameType != GameType.DiceBattle)
+        {
+            SetResponseErrorCode(response, (int)OperationStatusCode.Forbidden);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void CalculateWinners(List<long> playerIds, DiceBattleGameState game)
+    {
+        var max = 0;
+        foreach (var roleId in playerIds)
+        {
+            if (game.DiceMap.TryGetValue(roleId, out var value) && value > max)
+            {
+                max = value;
+            }
+        }
+
+        game.MaxDiceValue = max;
+        game.WinnerRoleIds.Clear();
+        foreach (var roleId in playerIds)
+        {
+            if (game.DiceMap.TryGetValue(roleId, out var value) && value == max)
+            {
+                game.WinnerRoleIds.Add(roleId);
+            }
+        }
+    }
+
+    private static bool CanRevealDice(RoomStatus roomStatus)
+    {
+        return roomStatus == RoomStatus.Settling || roomStatus == RoomStatus.Settled;
+    }
+
+    private static DiceBattleGameInfo ToMessage(DiceBattleGameState game, List<long> playerIds, bool revealDice)
+    {
+        return new DiceBattleGameInfo
+        {
+            RoomId = game.RoomId,
+            Round = game.Round,
+            WinnerRoleIds = revealDice ? new List<long>(game.WinnerRoleIds) : new List<long>(),
+            MaxDiceValue = revealDice ? game.MaxDiceValue : 0,
+            Players = playerIds.Select(roleId => new DiceBattlePlayerInfo
+            {
+                RoleId = roleId,
+                HasRolled = game.DiceMap.ContainsKey(roleId),
+                DiceValue = revealDice && game.DiceMap.TryGetValue(roleId, out var value) ? value : 0,
+            }).ToList(),
+        };
+    }
+
+    private static void SetResponseErrorCode(IResponseMessage response, int errorCode)
+    {
+        var propertyInfo = response.GetType().GetProperty(nameof(RespDiceBattleGameInfo.ErrorCode));
+        if (propertyInfo != null)
+        {
+            propertyInfo.SetValue(response, errorCode);
+        }
+    }
+
+    private static async Task NotifyGameChangedAsync(List<long> playerIds, DiceBattleGameInfo gameInfo)
+    {
+        var notify = new NotifyDiceBattleGameChanged
+        {
+            GameInfo = gameInfo,
+        };
+
+        foreach (var roleId in playerIds)
+        {
+            var session = SessionManager.GetByRoleId(roleId);
+            if (session != null)
+            {
+                await session.WriteAsync(notify);
+            }
+        }
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Game/DiceBattle/DiceBattleHandlerHelper.cs
+++ b/GameFrameX.Hotfix/Logic/Game/DiceBattle/DiceBattleHandlerHelper.cs
@@ -1,0 +1,40 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+using GameFrameX.Hotfix.Logic.Game.Room;
+
+namespace GameFrameX.Hotfix.Logic.Game.DiceBattle;
+
+internal static class DiceBattleHandlerHelper
+{
+    public static long GetCurrentRoleId(INetWorkChannel netWorkChannel)
+    {
+        return RoomHandlerHelper.GetCurrentRoleId(netWorkChannel);
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqDiceBattleGameInfoHandler.cs
+++ b/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqDiceBattleGameInfoHandler.cs
@@ -1,0 +1,47 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+namespace GameFrameX.Hotfix.Logic.Game.DiceBattle;
+
+[MessageMapping(typeof(ReqDiceBattleGameInfo))]
+internal sealed class ReqDiceBattleGameInfoHandler : GlobalRpcComponentHandler<DiceBattleGameComponentAgent, ReqDiceBattleGameInfo, RespDiceBattleGameInfo>
+{
+    protected override async Task ActionAsync(ReqDiceBattleGameInfo request, RespDiceBattleGameInfo response)
+    {
+        try
+        {
+            await ComponentAgent.OnReqGameInfoAsync(request, response);
+        }
+        catch (Exception e)
+        {
+            LogHelper.Fatal(e);
+            response.ErrorCode = (int)OperationStatusCode.InternalServerError;
+        }
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqRestartDiceBattleHandler.cs
+++ b/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqRestartDiceBattleHandler.cs
@@ -1,0 +1,48 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+namespace GameFrameX.Hotfix.Logic.Game.DiceBattle;
+
+[MessageMapping(typeof(ReqRestartDiceBattle))]
+internal sealed class ReqRestartDiceBattleHandler : GlobalRpcComponentHandler<DiceBattleGameComponentAgent, ReqRestartDiceBattle, RespRestartDiceBattle>
+{
+    protected override async Task ActionAsync(ReqRestartDiceBattle request, RespRestartDiceBattle response)
+    {
+        try
+        {
+            var roleId = DiceBattleHandlerHelper.GetCurrentRoleId(NetWorkChannel);
+            await ComponentAgent.OnRestartGameAsync(roleId, request, response);
+        }
+        catch (Exception e)
+        {
+            LogHelper.Fatal(e);
+            response.ErrorCode = (int)OperationStatusCode.InternalServerError;
+        }
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqRollDiceBattleHandler.cs
+++ b/GameFrameX.Hotfix/Logic/Game/DiceBattle/ReqRollDiceBattleHandler.cs
@@ -1,0 +1,48 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+namespace GameFrameX.Hotfix.Logic.Game.DiceBattle;
+
+[MessageMapping(typeof(ReqRollDiceBattle))]
+internal sealed class ReqRollDiceBattleHandler : GlobalRpcComponentHandler<DiceBattleGameComponentAgent, ReqRollDiceBattle, RespRollDiceBattle>
+{
+    protected override async Task ActionAsync(ReqRollDiceBattle request, RespRollDiceBattle response)
+    {
+        try
+        {
+            var roleId = DiceBattleHandlerHelper.GetCurrentRoleId(NetWorkChannel);
+            await ComponentAgent.OnRollDiceAsync(roleId, request, response);
+        }
+        catch (Exception e)
+        {
+            LogHelper.Fatal(e);
+            response.ErrorCode = (int)OperationStatusCode.InternalServerError;
+        }
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Game/Room/RoomComponentAgent.cs
+++ b/GameFrameX.Hotfix/Logic/Game/Room/RoomComponentAgent.cs
@@ -539,10 +539,40 @@ public class RoomComponentAgent : StateComponentAgent<RoomComponent, RoomListSta
             Room = await ToMessageAsync(room),
         };
 
-        var sessions = SessionManager.GetList(session => session.PlayerId > 0);
-        foreach (var session in sessions)
+        // 大厅可见的变化（房间增删、人数变化）需广播给所有在线玩家，以刷新房间列表。
+        // 其余为房间内部玩法事件（开始/结算/重置等），仅通知房间内成员，避免全服广播噪音。
+        if (IsLobbyVisibleChange(changeType))
         {
-            await session.WriteAsync(notify);
+            var sessions = SessionManager.GetList(session => session.PlayerId > 0);
+            foreach (var session in sessions)
+            {
+                await session.WriteAsync(notify);
+            }
+        }
+        else
+        {
+            await NotifyRoomMembersAsync(room, notify);
+        }
+    }
+
+    private static bool IsLobbyVisibleChange(RoomChangeType changeType)
+    {
+        return changeType == RoomChangeType.Created ||
+               changeType == RoomChangeType.Joined ||
+               changeType == RoomChangeType.Left ||
+               changeType == RoomChangeType.Closed ||
+               changeType == RoomChangeType.Disbanded;
+    }
+
+    private static async Task NotifyRoomMembersAsync(RoomState room, NotifyRoomChanged notify)
+    {
+        foreach (var roleId in room.PlayerIds)
+        {
+            var session = SessionManager.GetByRoleId(roleId);
+            if (session != null)
+            {
+                await session.WriteAsync(notify);
+            }
         }
     }
 

--- a/GameFrameX.Hotfix/Logic/Game/Room/RoomComponentAgent.cs
+++ b/GameFrameX.Hotfix/Logic/Game/Room/RoomComponentAgent.cs
@@ -55,6 +55,13 @@ public class RoomComponentAgent : StateComponentAgent<RoomComponent, RoomListSta
             MaxPlayerCount = 2,
             DefaultNamePrefix = "石头剪刀布房间",
         },
+        [GameType.DiceBattle] = new RoomRule
+        {
+            GameType = GameType.DiceBattle,
+            MinPlayerCount = 3,
+            MaxPlayerCount = 6,
+            DefaultNamePrefix = "掷骰子比大房间",
+        },
     };
 
     public override async Task<bool> Active()

--- a/GameFrameX.Proto/Proto/DiceBattle_420.cs
+++ b/GameFrameX.Proto/Proto/DiceBattle_420.cs
@@ -1,0 +1,281 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  or infringe upon the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+using System;
+using ProtoBuf;
+using System.Collections.Generic;
+using GameFrameX.NetWork.Abstractions;
+using GameFrameX.NetWork.Messages;
+
+namespace GameFrameX.Proto.Proto
+{
+	/// <summary>
+	/// 掷骰子比大小玩家信息
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("掷骰子比大小玩家信息")]
+	public sealed class DiceBattlePlayerInfo
+	{
+		/// <summary>
+		/// 玩家ID
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("玩家ID")]
+		public long RoleId { get; set; }
+
+		/// <summary>
+		/// 是否已掷骰
+		/// </summary>
+		[ProtoMember(2)]
+		[System.ComponentModel.Description("是否已掷骰")]
+		public bool HasRolled { get; set; }
+
+		/// <summary>
+		/// 骰子点数(1-6)。未结算前对外为0，结算后显示真实点数。
+		/// </summary>
+		[ProtoMember(3)]
+		[System.ComponentModel.Description("骰子点数(1-6)。未结算前对外为0，结算后显示真实点数。")]
+		public int DiceValue { get; set; }
+	}
+
+	/// <summary>
+	/// 掷骰子比大小游戏信息
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("掷骰子比大小游戏信息")]
+	public sealed class DiceBattleGameInfo
+	{
+		/// <summary>
+		/// 房间ID
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("房间ID")]
+		public long RoomId { get; set; }
+
+		/// <summary>
+		/// 当前局数
+		/// </summary>
+		[ProtoMember(2)]
+		[System.ComponentModel.Description("当前局数")]
+		public int Round { get; set; }
+
+		/// <summary>
+		/// 胜利玩家ID列表。点数最大者获胜，并列时全部返回；未结算前为空。
+		/// </summary>
+		[ProtoMember(3)]
+		[System.ComponentModel.Description("胜利玩家ID列表。点数最大者获胜，并列时全部返回；未结算前为空。")]
+		public List<long> WinnerRoleIds { get; set; } = new List<long>();
+
+		/// <summary>
+		/// 最大骰子点数。未结算前为0。
+		/// </summary>
+		[ProtoMember(4)]
+		[System.ComponentModel.Description("最大骰子点数。未结算前为0。")]
+		public int MaxDiceValue { get; set; }
+
+		/// <summary>
+		/// 玩家列表
+		/// </summary>
+		[ProtoMember(5)]
+		[System.ComponentModel.Description("玩家列表")]
+		public List<DiceBattlePlayerInfo> Players { get; set; } = new List<DiceBattlePlayerInfo>();
+	}
+
+	/// <summary>
+	/// 请求掷骰子比大小游戏信息
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("请求掷骰子比大小游戏信息")]
+	[MessageTypeHandler(((420) << 16) + 10)]
+	public sealed class ReqDiceBattleGameInfo : MessageObject, IRequestMessage
+	{
+		/// <summary>
+		/// 房间ID
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("房间ID")]
+		public long RoomId { get; set; }
+
+		public override void Clear()
+		{
+			RoomId = default;
+		}
+	}
+
+	/// <summary>
+	/// 返回掷骰子比大小游戏信息
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("返回掷骰子比大小游戏信息")]
+	[MessageTypeHandler(((420) << 16) + 11)]
+	public sealed class RespDiceBattleGameInfo : MessageObject, IResponseMessage
+	{
+		/// <summary>
+		/// 游戏信息
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("游戏信息")]
+		public DiceBattleGameInfo GameInfo { get; set; }
+
+		/// <summary>
+		/// 返回的错误码
+		/// </summary>
+		[ProtoMember(2047)]
+		[System.ComponentModel.Description("返回的错误码")]
+		public int ErrorCode { get; set; }
+
+		public override void Clear()
+		{
+			GameInfo = default;
+			ErrorCode = default;
+		}
+	}
+
+	/// <summary>
+	/// 请求掷骰子（服务器端生成点数）
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("请求掷骰子（服务器端生成点数）")]
+	[MessageTypeHandler(((420) << 16) + 12)]
+	public sealed class ReqRollDiceBattle : MessageObject, IRequestMessage
+	{
+		/// <summary>
+		/// 房间ID
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("房间ID")]
+		public long RoomId { get; set; }
+
+		public override void Clear()
+		{
+			RoomId = default;
+		}
+	}
+
+	/// <summary>
+	/// 返回掷骰子
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("返回掷骰子")]
+	[MessageTypeHandler(((420) << 16) + 13)]
+	public sealed class RespRollDiceBattle : MessageObject, IResponseMessage
+	{
+		/// <summary>
+		/// 游戏信息
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("游戏信息")]
+		public DiceBattleGameInfo GameInfo { get; set; }
+
+		/// <summary>
+		/// 返回的错误码
+		/// </summary>
+		[ProtoMember(2047)]
+		[System.ComponentModel.Description("返回的错误码")]
+		public int ErrorCode { get; set; }
+
+		public override void Clear()
+		{
+			GameInfo = default;
+			ErrorCode = default;
+		}
+	}
+
+	/// <summary>
+	/// 请求掷骰子比大小再来一局
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("请求掷骰子比大小再来一局")]
+	[MessageTypeHandler(((420) << 16) + 14)]
+	public sealed class ReqRestartDiceBattle : MessageObject, IRequestMessage
+	{
+		/// <summary>
+		/// 房间ID
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("房间ID")]
+		public long RoomId { get; set; }
+
+		public override void Clear()
+		{
+			RoomId = default;
+		}
+	}
+
+	/// <summary>
+	/// 返回掷骰子比大小再来一局
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("返回掷骰子比大小再来一局")]
+	[MessageTypeHandler(((420) << 16) + 15)]
+	public sealed class RespRestartDiceBattle : MessageObject, IResponseMessage
+	{
+		/// <summary>
+		/// 游戏信息
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("游戏信息")]
+		public DiceBattleGameInfo GameInfo { get; set; }
+
+		/// <summary>
+		/// 返回的错误码
+		/// </summary>
+		[ProtoMember(2047)]
+		[System.ComponentModel.Description("返回的错误码")]
+		public int ErrorCode { get; set; }
+
+		public override void Clear()
+		{
+			GameInfo = default;
+			ErrorCode = default;
+		}
+	}
+
+	/// <summary>
+	/// 通知掷骰子比大小游戏变化
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("通知掷骰子比大小游戏变化")]
+	[MessageTypeHandler(((420) << 16) + 16)]
+	public sealed class NotifyDiceBattleGameChanged : MessageObject, INotifyMessage
+	{
+		/// <summary>
+		/// 游戏信息
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("游戏信息")]
+		public DiceBattleGameInfo GameInfo { get; set; }
+
+		public override void Clear()
+		{
+			GameInfo = default;
+		}
+	}
+
+}

--- a/GameFrameX.Proto/Proto/Room_400.cs
+++ b/GameFrameX.Proto/Proto/Room_400.cs
@@ -54,6 +54,12 @@ namespace GameFrameX.Proto.Proto
 		/// </summary>
 		[System.ComponentModel.Description("石头剪刀布")]
 		RockPaperScissors = 1,
+
+		/// <summary>
+		/// 掷骰子比大小
+		/// </summary>
+		[System.ComponentModel.Description("掷骰子比大小")]
+		DiceBattle = 2,
 	}
 
 	/// <summary>


### PR DESCRIPTION
## 概述

实现 #56：为桌游/组队类游戏提供开房间方式的 DEMO。

closes #56

## 通用房间框架

提供完整可复用的开房间能力，任意玩法只需注册 `RoomRule` 并接入房间生命周期即可：

- **房间状态机**：`Waiting → Ready → Playing → Settling → Settled → Closed/Disbanded`
- **房间操作**：创建 / 加入 / 退出 / 房主开始 / 结算 / 再来一局
- **房间列表**：按游戏类型过滤、可选包含已关闭/已解散房间
- **连接生命周期联动**：断线标记重连中、登录重连清除标记、断线超时(120s)自动退出、已关闭房间保留 10min 后清理
- **已结算房间**：玩家新建/加入房间时自动关闭旧已结算房间
- **结算服务方法**（供玩法 Agent 调用）：`GetRoom` / `EnterSettling` / `MarkSettled` / `RestartRoomGame`

## DEMO 玩法

### 石头剪刀布（2 人）
验证基础房间闭环：提交手势 → 双方都提交进入结算 → 算胜负 → 房主重开。

### 掷骰子比大小（3-6 人）✨新增
验证 3+ 人组队场景下 `MinPlayerCount/MaxPlayerCount` 的通用性：
- 服务器端生成骰子点数（1-6），防篡改
- 全员掷骰后进入结算，**点数最大者获胜，并列时全部判胜**（多胜者形态）
- 复用房间生命周期，无额外状态机

## 通知策略优化 ✨

`NotifyRoomChangedAsync` 按受众分流，减少游戏内高频事件的全服广播：
- **大厅可见**（Created/Joined/Left/Closed/Disbanded）：广播全服，刷新房间列表
- **房间内部**（Started/Settling/Settled/Reset）：仅通知房间内成员

## 协议

| 段 | 用途 |
|----|------|
| `400` | 通用房间（枚举 / 房间信息 / 列表 / 创建 / 加入 / 退出 / 开始 / 变更通知） |
| `410` | 石头剪刀布 |
| `420` | 掷骰子比大小 |

## 验证

- [x] `dotnet build -c Release` 通过（0 警告 0 错误）
- [ ] 客户端联调（需配合客户端）
