### PR TITLE
feat(attributes): 增加玩家属性同步协议

### DIFF
--- a/GameFrameX.Apps.SelfCheck/AttributeSyncSelfCheck.cs
+++ b/GameFrameX.Apps.SelfCheck/AttributeSyncSelfCheck.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using GameFrameX.Apps.Player.Attribute;
+using GameFrameX.Apps.Player.Attribute.Entity;
+using GameFrameX.Hotfix.Logic.Player.Attribute;
+using GameFrameX.Proto.Proto;
+
+namespace GameFrameX.Apps.SelfCheck;
+
+internal static class AttributeSyncSelfCheck
+{
+    public static void Run()
+    {
+        // 增量构建
+        var changed = PlayerAttributeSyncBuilder.BuildChanged(AttributeType.Life, 1480L);
+        AssertEqual((int)AttributeType.Life, changed.Type, "BuildChanged.Type");
+        AssertEqual(1480L, changed.Value, "BuildChanged.Value");
+
+        // 快照构建
+        var state = new PlayerAttributeState();
+        state.Values[(int)AttributeType.LifeBase] = 1000L;
+        state.Values[(int)AttributeType.LifeAdd] = 200L;
+        state.Values[(int)AttributeType.LifePct] = 1500L;
+        state.Values[(int)AttributeType.Life] = 1480L;
+        state.Values[(int)AttributeType.PhysicalAttackBase] = 50L;
+        state.Values[(int)AttributeType.PhysicalAttack] = 50L;
+
+        var snapshot = PlayerAttributeSyncBuilder.BuildSnapshot(state);
+        // 最终值槽固定 9 个：Life / PhysicalAttack / MagicAttack / PhysicalDefense / MagicDefense / Critical / CriticalDamage / Precision / Block
+        AssertEqual(9, snapshot.Attributes.Count, "BuildSnapshot.Count");
+
+        var lifeEntry = snapshot.Attributes.Find(e => e.Type == (int)AttributeType.Life);
+        if (lifeEntry == null)
+        {
+            throw new InvalidOperationException("BuildSnapshot 缺少 Life 条目");
+        }
+
+        AssertEqual(1480L, lifeEntry.Value, "BuildSnapshot.Life.Value");
+        AssertEqual(1000L, lifeEntry.Base, "BuildSnapshot.Life.Base");
+        AssertEqual(200L, lifeEntry.Add, "BuildSnapshot.Life.Add");
+        AssertEqual(1500L, lifeEntry.Pct, "BuildSnapshot.Life.Pct");
+
+        // 缺失派生槽默认 0
+        var physicalAttackEntry = snapshot.Attributes.Find(e => e.Type == (int)AttributeType.PhysicalAttack);
+        if (physicalAttackEntry == null)
+        {
+            throw new InvalidOperationException("BuildSnapshot 缺少 PhysicalAttack 条目");
+        }
+
+        AssertEqual(50L, physicalAttackEntry.Value, "BuildSnapshot.PhysicalAttack.Value");
+        AssertEqual(50L, physicalAttackEntry.Base, "BuildSnapshot.PhysicalAttack.Base");
+        AssertEqual(0L, physicalAttackEntry.Add, "BuildSnapshot.PhysicalAttack.Add");
+
+        // 空状态快照仍包含全部最终值槽（值为 0）
+        var emptySnapshot = PlayerAttributeSyncBuilder.BuildSnapshot(new PlayerAttributeState());
+        AssertEqual(9, emptySnapshot.Attributes.Count, "BuildSnapshot.Empty.Count");
+    }
+
+    private static void AssertEqual<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(name + " 自检失败，expected=" + expected + ", actual=" + actual + "。");
+        }
+    }
+}

--- a/GameFrameX.Apps.SelfCheck/GameFrameX.Apps.SelfCheck.csproj
+++ b/GameFrameX.Apps.SelfCheck/GameFrameX.Apps.SelfCheck.csproj
@@ -12,6 +12,11 @@
       <Compile Include="..\GameFrameX.Apps\Player\Attribute\*.cs" Link="Player\Attribute\%(Filename)%(Extension)" />
       <Compile Include="..\GameFrameX.Apps\Player\Attribute\Entity\PlayerAttributeState.cs" Link="Player\Attribute\Entity\PlayerAttributeState.cs" />
       <Compile Include="..\GameFrameX.Hotfix\Logic\Player\Attribute\PlayerAttributeMutation.cs" Link="Player\Attribute\PlayerAttributeMutation.cs" />
+      <Compile Include="..\GameFrameX.Hotfix\Logic\Player\Attribute\PlayerAttributeSyncBuilder.cs" Link="Player\Attribute\PlayerAttributeSyncBuilder.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\GameFrameX.Proto\GameFrameX.Proto.csproj" />
     </ItemGroup>
 
 </Project>

--- a/GameFrameX.Apps.SelfCheck/Program.cs
+++ b/GameFrameX.Apps.SelfCheck/Program.cs
@@ -4,4 +4,5 @@ using GameFrameX.Apps.SelfCheck;
 
 AttributeCoreSelfCheck.Run();
 AttributeAgentSelfCheck.Run();
+AttributeSyncSelfCheck.Run();
 Console.WriteLine("AttributeSelfCheck PASS");

--- a/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeChangedEventListener.cs
+++ b/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeChangedEventListener.cs
@@ -1,0 +1,29 @@
+using GameFrameX.Apps.Common.Event;
+using GameFrameX.Apps.Common.EventData;
+using GameFrameX.Apps.Common.Session;
+using GameFrameX.Core.Abstractions.Events;
+
+namespace GameFrameX.Hotfix.Logic.Player.Attribute;
+
+/// <summary>
+/// 监听玩家最终属性变化，向在线玩家 session 推送增量同步消息。
+/// </summary>
+[Event(EventId.AttributeChanged)]
+internal sealed class PlayerAttributeChangedEventListener : EventListener<PlayerAttributeComponentAgent>
+{
+    protected override async Task HandleEvent(PlayerAttributeComponentAgent agent, GameEventArgs gameEventArgs)
+    {
+        if (agent == null || !(gameEventArgs is AttributeChangedEventArgs args))
+        {
+            return;
+        }
+
+        var session = SessionManager.GetByRoleId(args.PlayerId);
+        if (session == null)
+        {
+            return;
+        }
+
+        await session.WriteAsync(PlayerAttributeSyncBuilder.BuildChanged(args.AttributeType, args.NewValue));
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeComponentAgent.cs
+++ b/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeComponentAgent.cs
@@ -4,6 +4,7 @@ using GameFrameX.Apps.Player.Attribute;
 using GameFrameX.Apps.Player.Attribute.Component;
 using GameFrameX.Apps.Player.Attribute.Entity;
 using GameFrameX.Hotfix.Common.Events;
+using GameFrameX.Proto.Proto;
 
 namespace GameFrameX.Hotfix.Logic.Player.Attribute;
 
@@ -70,6 +71,15 @@ public class PlayerAttributeComponentAgent : StateComponentAgent<PlayerAttribute
         {
             await OwnerComponent.WriteStateAsync();
         }
+    }
+
+    /// <summary>
+    /// 构建当前玩家属性的完整快照消息，用于登录后或重连时同步给客户端。
+    /// </summary>
+    /// <returns>属性快照消息。</returns>
+    public NotifyPlayerAttributeSync BuildSyncSnapshot()
+    {
+        return PlayerAttributeSyncBuilder.BuildSnapshot(OwnerComponent.State);
     }
 
     private async Task Set(AttributeType attributeType, long value, bool silent)

--- a/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeSyncBuilder.cs
+++ b/GameFrameX.Hotfix/Logic/Player/Attribute/PlayerAttributeSyncBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using GameFrameX.Apps.Player.Attribute;
+using GameFrameX.Apps.Player.Attribute.Entity;
+using GameFrameX.Proto.Proto;
+
+namespace GameFrameX.Hotfix.Logic.Player.Attribute;
+
+/// <summary>
+/// 玩家属性同步消息构建器。把玩家属性状态和最终值变化转换为面向客户端的同步消息。
+/// </summary>
+public static class PlayerAttributeSyncBuilder
+{
+    /// <summary>
+    /// 根据玩家属性状态构建完整属性快照消息，包含全部最终值槽及其 Base/Add/Pct 调试字段。
+    /// </summary>
+    /// <param name="state">玩家属性状态。</param>
+    /// <returns>属性快照消息。</returns>
+    public static NotifyPlayerAttributeSync BuildSnapshot(PlayerAttributeState state)
+    {
+        if (state == null)
+        {
+            throw new ArgumentNullException(nameof(state));
+        }
+
+        var message = new NotifyPlayerAttributeSync();
+        foreach (AttributeType attributeType in Enum.GetValues(typeof(AttributeType)))
+        {
+            if (attributeType == AttributeType.None)
+            {
+                continue;
+            }
+
+            if (!AttributeCore.IsFinalAttribute(attributeType))
+            {
+                continue;
+            }
+
+            message.Attributes.Add(BuildEntry(state, attributeType));
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// 根据最终属性变化构建增量同步消息。
+    /// </summary>
+    /// <param name="attributeType">发生变化的最终属性编号。</param>
+    /// <param name="newValue">新的最终值。</param>
+    /// <returns>属性增量消息。</returns>
+    public static NotifyPlayerAttributeChanged BuildChanged(AttributeType attributeType, long newValue)
+    {
+        return new NotifyPlayerAttributeChanged
+        {
+            Type = (int)attributeType,
+            Value = newValue,
+        };
+    }
+
+    private static PlayerAttributeEntry BuildEntry(PlayerAttributeState state, AttributeType finalAttribute)
+    {
+        return new PlayerAttributeEntry
+        {
+            Type = (int)finalAttribute,
+            Value = state.GetValue(finalAttribute),
+            Base = state.GetValue(AttributeCore.GetSlotAttribute(finalAttribute, AttributeSlotKind.Base)),
+            Add = state.GetValue(AttributeCore.GetSlotAttribute(finalAttribute, AttributeSlotKind.Add)),
+            Pct = state.GetValue(AttributeCore.GetSlotAttribute(finalAttribute, AttributeSlotKind.Pct)),
+        };
+    }
+}

--- a/GameFrameX.Hotfix/Logic/Player/Login/PlayerComponentAgent.cs
+++ b/GameFrameX.Hotfix/Logic/Player/Login/PlayerComponentAgent.cs
@@ -34,6 +34,7 @@ using GameFrameX.Apps.Common.Session;
 using GameFrameX.Apps.Player.Player.Component;
 using GameFrameX.Apps.Player.Player.Entity;
 using GameFrameX.Hotfix.Logic.Game.Room;
+using GameFrameX.Hotfix.Logic.Player.Attribute;
 using GameFrameX.Hotfix.Logic.Server;
 
 namespace GameFrameX.Hotfix.Logic.Player.Login;
@@ -78,5 +79,9 @@ public class PlayerComponentAgent : StateComponentAgent<PlayerComponent, PlayerS
 
         var roomComp = await ActorManager.GetComponentAgent<RoomComponentAgent>();
         await roomComp.MarkPlayerReconnected(ActorId);
+
+        // 推送玩家属性完整快照，供客户端初始化属性显示
+        var attributeAgent = await ActorManager.GetComponentAgent<PlayerAttributeComponentAgent>(ActorId);
+        await workChannel.WriteAsync(attributeAgent.BuildSyncSnapshot());
     }
 }

--- a/GameFrameX.Proto/Proto/Attribute_310.cs
+++ b/GameFrameX.Proto/Proto/Attribute_310.cs
@@ -1,0 +1,133 @@
+// ==========================================================================================
+//  GameFrameX 组织及其衍生项目的版权、商标、专利及其他相关权利
+//  GameFrameX organization and its derivative projects' copyrights, trademarks, patents, and related rights
+//  均受中华人民共和国及相关国际法律法规保护。
+//  are protected by the laws of the People's Republic of China and relevant international regulations.
+//
+//  使用本项目须严格遵守相应法律法规及开源许可证之规定。
+//  Usage of this project must strictly comply with applicable laws, regulations, and open-source licenses.
+//
+//  本项目采用 MIT 许可证与 Apache License 2.0 双许可证分发，
+//  This project is dual-licensed under the MIT License and Apache License 2.0,
+//  完整许可证文本请参见源代码根目录下的 LICENSE 文件。
+//  please refer to the LICENSE file in the root directory of the source code for the full license text.
+//
+//  禁止利用本项目实施任何危害国家安全、破坏社会秩序、
+//  It is prohibited to use this project to engage in any activities that endanger national security, disrupt social order,
+//  侵犯他人合法权益等法律法规所禁止的行为！
+//  or infringe on the legitimate rights and interests of others, as prohibited by laws and regulations!
+//  因基于本项目二次开发所产生的一切法律纠纷与责任，
+//  Any legal disputes and liabilities arising from secondary development based on this project
+//  本项目组织与贡献者概不承担。
+//  shall be borne solely by the developer; the project organization and contributors assume no responsibility.
+//
+//  GitHub 仓库：https://github.com/GameFrameX
+//  GitHub Repository: https://github.com/GameFrameX
+//  Gitee  仓库：https://gitee.com/GameFrameX
+//  Gitee Repository:  https://gitee.com/GameFrameX
+//  官方文档：https://gameframex.doc.alianblank.com/
+//  Official Documentation: https://gameframex.doc.alianblank.com/
+// ==========================================================================================
+
+using System;
+using ProtoBuf;
+using System.Collections.Generic;
+using GameFrameX.NetWork.Abstractions;
+using GameFrameX.NetWork.Messages;
+
+namespace GameFrameX.Proto.Proto
+{
+	/// <summary>
+	/// 玩家属性条目，含最终值与 Base/Add/Pct 调试字段
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("玩家属性条目，含最终值与 Base/Add/Pct 调试字段")]
+	public sealed class PlayerAttributeEntry
+	{
+		/// <summary>
+		/// 属性编号（AttributeType）
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("属性编号（AttributeType）")]
+		public int Type { get; set; }
+
+		/// <summary>
+		/// 最终值
+		/// </summary>
+		[ProtoMember(2)]
+		[System.ComponentModel.Description("最终值")]
+		public long Value { get; set; }
+
+		/// <summary>
+		/// 基础值（调试字段）
+		/// </summary>
+		[ProtoMember(3)]
+		[System.ComponentModel.Description("基础值（调试字段）")]
+		public long Base { get; set; }
+
+		/// <summary>
+		/// 加法修正（调试字段）
+		/// </summary>
+		[ProtoMember(4)]
+		[System.ComponentModel.Description("加法修正（调试字段）")]
+		public long Add { get; set; }
+
+		/// <summary>
+		/// 百分比修正，10000 表示 100%（调试字段）
+		/// </summary>
+		[ProtoMember(5)]
+		[System.ComponentModel.Description("百分比修正，10000 表示 100%（调试字段）")]
+		public long Pct { get; set; }
+	}
+
+	/// <summary>
+	/// 玩家属性完整快照（服务端推送，登录后或重连时发送）
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("玩家属性完整快照（服务端推送，登录后或重连时发送）")]
+	[MessageTypeHandler(((310) << 16) + 10)]
+	public sealed class NotifyPlayerAttributeSync : MessageObject, INotifyMessage
+	{
+		/// <summary>
+		/// 全部最终属性条目
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("全部最终属性条目")]
+		public List<PlayerAttributeEntry> Attributes { get; set; } = new List<PlayerAttributeEntry>();
+
+		public override void Clear()
+		{
+			Attributes.Clear();
+		}
+	}
+
+	/// <summary>
+	/// 单个玩家属性最终值变化（服务端推送增量）
+	/// </summary>
+	[ProtoContract]
+	[System.ComponentModel.Description("单个玩家属性最终值变化（服务端推送增量）")]
+	[MessageTypeHandler(((310) << 16) + 11)]
+	public sealed class NotifyPlayerAttributeChanged : MessageObject, INotifyMessage
+	{
+		/// <summary>
+		/// 发生变化的最终属性编号（AttributeType）
+		/// </summary>
+		[ProtoMember(1)]
+		[System.ComponentModel.Description("发生变化的最终属性编号（AttributeType）")]
+		public int Type { get; set; }
+
+		/// <summary>
+		/// 新的最终值
+		/// </summary>
+		[ProtoMember(2)]
+		[System.ComponentModel.Description("新的最终值")]
+		public long Value { get; set; }
+
+		public override void Clear()
+		{
+			Type = default;
+			Value = default;
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
- 新增玩家属性同步协议消息：`PlayerAttributeEntry` / `NotifyPlayerAttributeSync`（完整快照）/ `NotifyPlayerAttributeChanged`（单属性增量），含可选 Base/Add/Pct 调试字段
- 登录成功后向客户端推送属性完整快照；当最终属性值发生变化时推送增量同步
- 服务端权威单向推送（仅 `INotifyMessage`），客户端只消费用于显示，无任何客户端写入口
- 通过现有 `PlayerAttributeMutation.ApplyValue.ShouldDispatch` 路由增量同步，避免无意义变更推送；重复登录不会重复初始化或推送无意义变化
- 新增 `AttributeSyncSelfCheck` 覆盖快照（含最终值槽固定 9 个、Base/Add/Pct 派生槽、空状态默认 0）与增量构建

## Test plan
- [x] `dotnet build Server.sln` 0 error
- [x] `dotnet run --project GameFrameX.Apps.SelfCheck` 输出 `AttributeSelfCheck PASS`
- [x] `dotnet test Server.sln` exit 0
- [x] 新增协议 opcode 全局唯一（`(310<<16)+10` / `(310<<16)+11`）
- [x] 事件监听器为 `sealed`，无 `IRequestMessage` 客户端写入口（服务端权威）
- [x] 登录推送顺序：`AddOnlineRole` → `MarkPlayerReconnected` → 属性快照
- [x] 仅最终值真实变化时派发增量同步

Closes GFX-128